### PR TITLE
Don't look at JSON id after freeing it.

### DIFF
--- a/lxpanel-plugin-notifications/config.c
+++ b/lxpanel-plugin-notifications/config.c
@@ -95,7 +95,7 @@ gboolean is_user_registered()
 	/* Open the JSON */
 	JSON_Value *root_value = NULL;
 	JSON_Object *root = NULL;
-	const gchar *id = NULL;
+	gchar *id = NULL;
 
 	root_value = json_parse_file(profile);
 	g_free(profile);
@@ -110,8 +110,9 @@ gboolean is_user_registered()
 
 	root = json_value_get_object(root_value);
 	id = json_object_get_string(root, "kanoworld_id");
+	bool retval = (id != NULL) && strlen(id) > 0;
 	json_value_free(root_value);
-	return (id != NULL) && strlen(id) > 0;
+	return retval;
 }
 
 


### PR DESCRIPTION
This PR fixes the use-after-free warned about by valgrind.
@skarbat @tombettany @pazdera 
