### PR TITLE
Free after removing from list.

### DIFF
--- a/lxpanel-plugin-notifications/ui.c
+++ b/lxpanel-plugin-notifications/ui.c
@@ -462,8 +462,8 @@ gboolean close_notification(kano_notifications_t *plugin_data)
 		plugin_data->window = NULL;
 
 		notification_info_t *notification = g_list_nth_data(plugin_data->queue, 0);
-		free_notification(notification);
 		plugin_data->queue = g_list_remove(plugin_data->queue, notification);
+		free_notification(notification);
 
 
 		if (g_list_length(plugin_data->queue) >= 1) {


### PR DESCRIPTION
This PR moves a free to after we remove the notification from a list. The list entry itself is freed so we should not be relying on its pointers.
However this does not fix the current problem. @tombettany @skarbat 
