### PR TITLE
[OS-543] Remove dependency on kano-peripherals, fix another dependency loop

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 kano-widgets (4.2.1-0) unstable; urgency=low
 
   * Removed dependency on kano-profile, fix dependency loop
+  * Removed dependency on kano-peripherals, fix dependency loop
 
  -- Team Kano <dev@kano.me>  Tue, 22 Jan 2019 11:14:00 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -20,8 +20,7 @@ Depends:
     ${misc:Depends},
     kano-sound-files,
     libkdesk-dev (>= 1.1-9),
-    kano-toolset (>= 2.1-1),
-    kano-peripherals
+    kano-toolset (>= 2.1-1)
 Description: Collection of Kano lxpanel widgets
 
 Package: kano-widgets-i18n-orig


### PR DESCRIPTION
Full documentation in Confluence - [Fixing the Dependency Tree](https://kanocomputing.atlassian.net/wiki/spaces/OS/pages/99254331/Fixing+the+Dependency+Tree)